### PR TITLE
Add category selection settings to popup and other small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ Product in early stages of development and I will continue working on it for as 
 </a>
 
 ## Overview
-
 Having a player driven economy, products can be found selling at a wide range of prices every day, so finding the best prices is no easy task.
 
 Hence why I have transformed pages like the market to give you all the information you need:
@@ -19,7 +18,6 @@ Hence why I have transformed pages like the market to give you all the informati
 </p>
 
 ## Features
-
 You will now immediately see:
 
 - **Items on sale** - displays an icon with how much cheaper (%) an item is compared to its current market price.
@@ -37,7 +35,6 @@ Updating the price of an item listed on the market will repeat that action for a
 Also add a sidebar to help navigate between stores (market, NPC, last visited bazaar, ...) with one click.
 
 ## Customization
-
 The browser popup is used to set the API key (required) and customize parameters to your liking:
 - **Minimum profit** - Minimum profit amount to display the highlight and profit on items
 - **Minimum sale (%)** - Minimum profit percentage to display the highlight and icon on items

--- a/extension/popup/popup.css
+++ b/extension/popup/popup.css
@@ -13,7 +13,12 @@
   padding: 5px;
 }
 
-.text-align-center {
+.update-buttons {
+  text-align: center;
+  margin: 5px;
+}
+
+.align-center {
   text-align: center;
 }
 
@@ -32,14 +37,15 @@ input[type=number] {
 /* collapsible elements */
 .collapsible {
   background-color: #eee;
-  color: #444;
+  color: rgb(44, 44, 44);
   cursor: pointer;
   padding: 2px 5px;
   width: 100%;
-  border: none;
+  border: 2px solid #838383;
   text-align: left;
   outline: none;
   font-size: 15px;
+  margin-top: 2px;
 }
 .active, .collapsible:hover {
   background-color: #ccc;
@@ -48,6 +54,8 @@ input[type=number] {
   display: none;
   overflow: hidden;
   background-color: #f1f1f1;
+  margin-bottom: 2px;
+  border: 1px solid #525252;
 }
 .collapsible:after {
   content: '\02795'; /* Unicode character for "plus" sign (+) */
@@ -64,4 +72,5 @@ input[type=number] {
 table, th, td {
   border: 1px solid black;
   border-collapse: collapse;
+  text-align: center;
 }

--- a/extension/popup/popup.css
+++ b/extension/popup/popup.css
@@ -5,7 +5,6 @@
 .input-small {
   max-width: 30px;
 }
-
 .input-normal {
   max-width: 100px;
 }
@@ -18,14 +17,51 @@
   text-align: center;
 }
 
+/* Hide input arrows */
 /* Chrome */
 input::-webkit-outer-spin-button,
 input::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
 }
-
 /* Firefox */
 input[type=number] {
   -moz-appearance: textfield;
+}
+
+/* collapsible elements */
+.collapsible {
+  background-color: #eee;
+  color: #444;
+  cursor: pointer;
+  padding: 2px 5px;
+  width: 100%;
+  border: none;
+  text-align: left;
+  outline: none;
+  font-size: 15px;
+}
+.active, .collapsible:hover {
+  background-color: #ccc;
+}
+.content {
+  display: none;
+  overflow: hidden;
+  background-color: #f1f1f1;
+}
+.collapsible:after {
+  content: '\02795'; /* Unicode character for "plus" sign (+) */
+  font-size: 13px;
+  color: white;
+  float: right;
+  margin-left: 5px;
+}
+.active:after {
+  content: "\2796"; /* Unicode character for "minus" sign (-) */
+}
+
+/* Table */
+table, th, td {
+  border: 1px solid black;
+  border-collapse: collapse;
 }

--- a/extension/popup/popup.html
+++ b/extension/popup/popup.html
@@ -9,23 +9,174 @@
   <body class="body">
     <div id="popup-content">
         <div class="padding">
-            API Key: <input type="text" id="apikey" placeholder="XXXXXXX">
+            API Key: <input type="text" id="apikey" placeholder="Missing API key">
             <button id="apikeybtn">Set</button>
         </div>
-        <div class="padding">
+
+        <!-- Settings -->
+        <button type="button" class="collapsible">Values</button>
+        <div class="content">
+
+          <div class="padding">
             Minimum profit: <input type="number" id="minProfit" placeholder="1000" value="1000" min="1" class="input-normal">
+          </div>
+          <div class="padding">
+              Minimum sale (%): <input type="number" id="minPercentage" size="3" placeholder="25%" value="25" min="1" max="100" class="input-small">
+          </div>
+          <div class="padding">
+              Minimum piggy bank value: <input type="number" id="minPiggyBankValue" placeholder="20000" value="20000" min="1" class="input-normal">
+          </div>
+          <div class="padding">
+              Maximum piggy bank expense: <input type="number" id="maxPiggyBankExpense" placeholder="450" value="450" min="1" class="input-normal">
+          </div>
+          <div class="text-align-center">
+            <button id="valuesbtn">Update values</button>
+          </div>
+
         </div>
-        <div class="padding">
-            Minimum sale (%): <input type="number" id="minPercentage" size="3" placeholder="25%" value="25" min="1" max="100" class="input-small">
-        </div>
-        <div class="padding">
-            Minimum piggy bank value: <input type="number" id="minPiggyBankValue" placeholder="20000" value="20000" min="1" class="input-normal">
-        </div>
-        <div class="padding">
-            Maximum piggy bank expense: <input type="number" id="maxPiggyBankExpense" placeholder="450" value="450" min="1" class="input-normal">
-        </div>
-        <div class="text-align-center">
-          <button id="valuesbtn">Update values</button>
+
+        <!-- Category selection options -->
+        <button type="button" class="collapsible">Category selection</button>
+        <div class="content">
+
+          <p style="color: green;margin: 5px;">R. NPC - Profit reselling to NPC shops</p>
+          <p style="color: red;margin: 5px;">R. Market - Profit reselling in the Market</p>
+
+          <table style="width:100%;">
+            <thead>
+              <tr>
+                <th style="color: green;">R. NPC</th>
+                <th style="color: red;">R. Market</th>
+                <th>Category</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><input type="checkbox" name="resell_npc_option" value="Melee"></td>
+                <td><input type="checkbox" name="resell_market_option" value="Melee"></td>
+                <td>Melee Weapon</td>
+              </tr>
+              <tr>
+                <td><input type="checkbox" name="resell_npc_option" value="Primary"></td>
+                <td><input type="checkbox" name="resell_market_option" value="Primary"></td>
+                <td>Primary Weapon</td>
+              </tr>
+              <tr>
+                <td><input type="checkbox" name="resell_npc_option" value="Secondary"></td>
+                <td><input type="checkbox" name="resell_market_option" value="Secondary"></td>
+                <td>Secondary Weapon</td>
+              </tr>
+              <tr>
+                <td><input type="checkbox" name="resell_npc_option" value="Defensive"></td>
+                <td><input type="checkbox" name="resell_market_option" value="Defensive"></td>
+                <td>Armor</td>
+              </tr>
+              <tr>
+                <td><input type="checkbox" name="resell_npc_option" value="Medical"></td>
+                <td><input type="checkbox" name="resell_market_option" value="Medical"></td>
+                <td>Medical Items</td>
+              </tr>
+              <tr>
+                <td><input type="checkbox" name="resell_npc_option" value="Temporary"></td>
+                <td><input type="checkbox" name="resell_market_option" value="Temporary"></td>
+                <td>Temporary Items</td>
+              </tr>
+              <tr>
+                <td><input type="checkbox" name="resell_npc_option" value="Energy"></td>
+                <td><input type="checkbox" name="resell_market_option" value="Energy"></td>
+                <td>Energy Drinks</td>
+              </tr>
+              <tr>
+                <td><input type="checkbox" name="resell_npc_option" value="Candy"></td>
+                <td><input type="checkbox" name="resell_market_option" value="Candy"></td>
+                <td>Candy</td>
+              </tr>
+              <tr>
+                <td><input type="checkbox" name="resell_npc_option" value="Drug"></td>
+                <td><input type="checkbox" name="resell_market_option" value="Drug"></td>
+                <td>Drugs</td>
+              </tr>
+              <tr>
+                <td><input type="checkbox" name="resell_npc_option" value="Enhancer"></td>
+                <td><input type="checkbox" name="resell_market_option" value="Enhancer"></td>
+                <td>Enhancers</td>
+              </tr>
+              <tr>
+                <td><input type="checkbox" name="resell_npc_option" value="Alcohol"></td>
+                <td><input type="checkbox" name="resell_market_option" value="Alcohol"></td>
+                <td>Alcohol</td>
+              </tr>
+              <tr>
+                <td><input type="checkbox" name="resell_npc_option" value="Booster"></td>
+                <td><input type="checkbox" name="resell_market_option" value="Booster"></td>
+                <td>Other Boosters</td>
+              </tr>
+              <tr>
+                <td><input type="checkbox" name="resell_npc_option" value="Electronic"></td>
+                <td><input type="checkbox" name="resell_market_option" value="Electronic"></td>
+                <td>Electronics</td>
+              </tr>
+              <tr>
+                <td><input type="checkbox" name="resell_npc_option" value="Jewelry"></td>
+                <td><input type="checkbox" name="resell_market_option" value="Jewelry"></td>
+                <td>Jewelry</td>
+              </tr>
+              <tr>
+                <td><input type="checkbox" name="resell_npc_option" value="Virus"></td>
+                <td><input type="checkbox" name="resell_market_option" value="Virus"></td>
+                <td>Viruses</td>
+              </tr>
+              <tr>
+                <td><input type="checkbox" name="resell_npc_option" value="Flower"></td>
+                <td><input type="checkbox" name="resell_market_option" value="Flower"></td>
+                <td>Flowers</td>
+              </tr>
+              <tr>
+                <td><input type="checkbox" name="resell_npc_option" value="Supply Pack"></td>
+                <td><input type="checkbox" name="resell_market_option" value="Supply Pack"></td>
+                <td>Supply Packs</td>
+              </tr>
+              <tr>
+                <td><input type="checkbox" name="resell_npc_option" value="Collectible"></td>
+                <td><input type="checkbox" name="resell_market_option" value="Collectible"></td>
+                <td>Collectibles</td>
+              </tr>
+              <tr>
+                <td><input type="checkbox" name="resell_npc_option" value="Clothing"></td>
+                <td><input type="checkbox" name="resell_market_option" value="Clothing"></td>
+                <td>Clothing</td>
+              </tr>
+              <tr>
+                <td><input type="checkbox" name="resell_npc_option" value="Car"></td>
+                <td><input type="checkbox" name="resell_market_option" value="Car"></td>
+                <td>Cars</td>
+              </tr>
+              <tr>
+                <td><input type="checkbox" name="resell_npc_option" value="Artifact"></td>
+                <td><input type="checkbox" name="resell_market_option" value="Artifact"></td>
+                <td>Artifacts</td>
+              </tr>
+              <tr>
+                <td><input type="checkbox" name="resell_npc_option" value="Plushie"></td>
+                <td><input type="checkbox" name="resell_market_option" value="Plushie"></td>
+                <td>Plushies</td>
+              </tr>
+              <tr>
+                <td><input type="checkbox" name="resell_npc_option" value="Special"></td>
+                <td><input type="checkbox" name="resell_market_option" value="Special"></td>
+                <td>Special Items</td>
+              </tr>
+              <tr>
+                <td><input type="checkbox" name="resell_npc_option" value="Other"></td>
+                <td><input type="checkbox" name="resell_market_option" value="Other"></td>
+                <td>Miscellaneous</td>
+              </tr>
+            </tbody>
+          </table>
+          <div class="text-align-center">
+            <button id="settingsbtn">Update settings</button>
+          </div>
+
         </div>
     </div>
     <script src="popup.js"></script>

--- a/extension/popup/popup.html
+++ b/extension/popup/popup.html
@@ -29,151 +29,177 @@
           <div class="padding">
               Maximum piggy bank expense: <input type="number" id="maxPiggyBankExpense" placeholder="450" value="450" min="1" class="input-normal">
           </div>
-          <div class="text-align-center">
+          <div class="update-buttons">
             <button id="valuesbtn">Update values</button>
           </div>
 
         </div>
 
         <!-- Category selection options -->
-        <button type="button" class="collapsible">Category selection</button>
+        <button type="button" class="collapsible">Category settings</button>
         <div class="content">
 
-          <p style="color: green;margin: 5px;">R. NPC - Profit reselling to NPC shops</p>
-          <p style="color: red;margin: 5px;">R. Market - Profit reselling in the Market</p>
+          <p style="color: green;margin: 5px;">Shops - Profit reselling to NPC shops</p>
+          <p style="color: red;margin: 5px;">Market - Profit reselling in the Market</p>
+          <p style="margin: 5px;">Sales - Items for sale</p>
 
-          <table style="width:100%;">
+          <table style="width: 97%;margin-left: 4px;">
             <thead>
               <tr>
-                <th style="color: green;">R. NPC</th>
-                <th style="color: red;">R. Market</th>
                 <th>Category</th>
+                <th style="color: green;">Shops</th>
+                <th style="color: red;">Market</th>
+                <th>Sales</th>
               </tr>
             </thead>
             <tbody>
               <tr>
-                <td><input type="checkbox" name="resell_npc_option" value="Melee"></td>
-                <td><input type="checkbox" name="resell_market_option" value="Melee"></td>
                 <td>Melee Weapon</td>
+                <td><input type="checkbox" name="resell_shops_option" value="Melee"></td>
+                <td><input type="checkbox" name="resell_market_option" value="Melee"></td>
+                <td><input type="checkbox" name="sale_option" value="Melee"></td>
               </tr>
               <tr>
-                <td><input type="checkbox" name="resell_npc_option" value="Primary"></td>
-                <td><input type="checkbox" name="resell_market_option" value="Primary"></td>
                 <td>Primary Weapon</td>
+                <td><input type="checkbox" name="resell_shops_option" value="Primary"></td>
+                <td><input type="checkbox" name="resell_market_option" value="Primary"></td>
+                <td><input type="checkbox" name="sale_option" value="Primary"></td>
               </tr>
               <tr>
-                <td><input type="checkbox" name="resell_npc_option" value="Secondary"></td>
-                <td><input type="checkbox" name="resell_market_option" value="Secondary"></td>
                 <td>Secondary Weapon</td>
+                <td><input type="checkbox" name="resell_shops_option" value="Secondary"></td>
+                <td><input type="checkbox" name="resell_market_option" value="Secondary"></td>
+                <td><input type="checkbox" name="sale_option" value="Secondary"></td>
               </tr>
               <tr>
-                <td><input type="checkbox" name="resell_npc_option" value="Defensive"></td>
-                <td><input type="checkbox" name="resell_market_option" value="Defensive"></td>
                 <td>Armor</td>
+                <td><input type="checkbox" name="resell_shops_option" value="Defensive"></td>
+                <td><input type="checkbox" name="resell_market_option" value="Defensive"></td>
+                <td><input type="checkbox" name="sale_option" value="Defensive"></td>
               </tr>
               <tr>
-                <td><input type="checkbox" name="resell_npc_option" value="Medical"></td>
-                <td><input type="checkbox" name="resell_market_option" value="Medical"></td>
                 <td>Medical Items</td>
+                <td><input type="checkbox" name="resell_shops_option" value="Medical"></td>
+                <td><input type="checkbox" name="resell_market_option" value="Medical"></td>
+                <td><input type="checkbox" name="sale_option" value="Medical"></td>
               </tr>
               <tr>
-                <td><input type="checkbox" name="resell_npc_option" value="Temporary"></td>
-                <td><input type="checkbox" name="resell_market_option" value="Temporary"></td>
                 <td>Temporary Items</td>
+                <td><input type="checkbox" name="resell_shops_option" value="Temporary"></td>
+                <td><input type="checkbox" name="resell_market_option" value="Temporary"></td>
+                <td><input type="checkbox" name="sale_option" value="Temporary"></td>
               </tr>
               <tr>
-                <td><input type="checkbox" name="resell_npc_option" value="Energy"></td>
-                <td><input type="checkbox" name="resell_market_option" value="Energy"></td>
                 <td>Energy Drinks</td>
+                <td><input type="checkbox" name="resell_shops_option" value="Energy Drink"></td>
+                <td><input type="checkbox" name="resell_market_option" value="Energy Drink"></td>
+                <td><input type="checkbox" name="sale_option" value="Energy Drink"></td>
               </tr>
               <tr>
-                <td><input type="checkbox" name="resell_npc_option" value="Candy"></td>
-                <td><input type="checkbox" name="resell_market_option" value="Candy"></td>
                 <td>Candy</td>
+                <td><input type="checkbox" name="resell_shops_option" value="Candy"></td>
+                <td><input type="checkbox" name="resell_market_option" value="Candy"></td>
+                <td><input type="checkbox" name="sale_option" value="Candy"></td>
               </tr>
               <tr>
-                <td><input type="checkbox" name="resell_npc_option" value="Drug"></td>
-                <td><input type="checkbox" name="resell_market_option" value="Drug"></td>
                 <td>Drugs</td>
+                <td><input type="checkbox" name="resell_shops_option" value="Drug"></td>
+                <td><input type="checkbox" name="resell_market_option" value="Drug"></td>
+                <td><input type="checkbox" name="sale_option" value="Drug"></td>
               </tr>
               <tr>
-                <td><input type="checkbox" name="resell_npc_option" value="Enhancer"></td>
-                <td><input type="checkbox" name="resell_market_option" value="Enhancer"></td>
                 <td>Enhancers</td>
+                <td><input type="checkbox" name="resell_shops_option" value="Enhancer"></td>
+                <td><input type="checkbox" name="resell_market_option" value="Enhancer"></td>
+                <td><input type="checkbox" name="sale_option" value="Enhancer"></td>
               </tr>
               <tr>
-                <td><input type="checkbox" name="resell_npc_option" value="Alcohol"></td>
-                <td><input type="checkbox" name="resell_market_option" value="Alcohol"></td>
                 <td>Alcohol</td>
+                <td><input type="checkbox" name="resell_shops_option" value="Alcohol"></td>
+                <td><input type="checkbox" name="resell_market_option" value="Alcohol"></td>
+                <td><input type="checkbox" name="sale_option" value="Alcohol"></td>
               </tr>
               <tr>
-                <td><input type="checkbox" name="resell_npc_option" value="Booster"></td>
-                <td><input type="checkbox" name="resell_market_option" value="Booster"></td>
                 <td>Other Boosters</td>
+                <td><input type="checkbox" name="resell_shops_option" value="Booster"></td>
+                <td><input type="checkbox" name="resell_market_option" value="Booster"></td>
+                <td><input type="checkbox" name="sale_option" value="Booster"></td>
               </tr>
               <tr>
-                <td><input type="checkbox" name="resell_npc_option" value="Electronic"></td>
-                <td><input type="checkbox" name="resell_market_option" value="Electronic"></td>
                 <td>Electronics</td>
+                <td><input type="checkbox" name="resell_shops_option" value="Electronic"></td>
+                <td><input type="checkbox" name="resell_market_option" value="Electronic"></td>
+                <td><input type="checkbox" name="sale_option" value="Electronic"></td>
               </tr>
               <tr>
-                <td><input type="checkbox" name="resell_npc_option" value="Jewelry"></td>
-                <td><input type="checkbox" name="resell_market_option" value="Jewelry"></td>
                 <td>Jewelry</td>
+                <td><input type="checkbox" name="resell_shops_option" value="Jewelry"></td>
+                <td><input type="checkbox" name="resell_market_option" value="Jewelry"></td>
+                <td><input type="checkbox" name="sale_option" value="Jewelry"></td>
               </tr>
               <tr>
-                <td><input type="checkbox" name="resell_npc_option" value="Virus"></td>
-                <td><input type="checkbox" name="resell_market_option" value="Virus"></td>
                 <td>Viruses</td>
+                <td><input type="checkbox" name="resell_shops_option" value="Virus"></td>
+                <td><input type="checkbox" name="resell_market_option" value="Virus"></td>
+                <td><input type="checkbox" name="sale_option" value="Virus"></td>
               </tr>
               <tr>
-                <td><input type="checkbox" name="resell_npc_option" value="Flower"></td>
-                <td><input type="checkbox" name="resell_market_option" value="Flower"></td>
                 <td>Flowers</td>
+                <td><input type="checkbox" name="resell_shops_option" value="Flower"></td>
+                <td><input type="checkbox" name="resell_market_option" value="Flower"></td>
+                <td><input type="checkbox" name="sale_option" value="Flower"></td>
               </tr>
               <tr>
-                <td><input type="checkbox" name="resell_npc_option" value="Supply Pack"></td>
-                <td><input type="checkbox" name="resell_market_option" value="Supply Pack"></td>
                 <td>Supply Packs</td>
+                <td><input type="checkbox" name="resell_shops_option" value="Supply Pack"></td>
+                <td><input type="checkbox" name="resell_market_option" value="Supply Pack"></td>
+                <td><input type="checkbox" name="sale_option" value="Supply Pack"></td>
               </tr>
               <tr>
-                <td><input type="checkbox" name="resell_npc_option" value="Collectible"></td>
-                <td><input type="checkbox" name="resell_market_option" value="Collectible"></td>
                 <td>Collectibles</td>
+                <td><input type="checkbox" name="resell_shops_option" value="Collectible"></td>
+                <td><input type="checkbox" name="resell_market_option" value="Collectible"></td>
+                <td><input type="checkbox" name="sale_option" value="Collectible"></td>
               </tr>
               <tr>
-                <td><input type="checkbox" name="resell_npc_option" value="Clothing"></td>
-                <td><input type="checkbox" name="resell_market_option" value="Clothing"></td>
                 <td>Clothing</td>
+                <td><input type="checkbox" name="resell_shops_option" value="Clothing"></td>
+                <td><input type="checkbox" name="resell_market_option" value="Clothing"></td>
+                <td><input type="checkbox" name="sale_option" value="Clothing"></td>
               </tr>
               <tr>
-                <td><input type="checkbox" name="resell_npc_option" value="Car"></td>
-                <td><input type="checkbox" name="resell_market_option" value="Car"></td>
                 <td>Cars</td>
+                <td><input type="checkbox" name="resell_shops_option" value="Car"></td>
+                <td><input type="checkbox" name="resell_market_option" value="Car"></td>
+                <td><input type="checkbox" name="sale_option" value="Car"></td>
               </tr>
               <tr>
-                <td><input type="checkbox" name="resell_npc_option" value="Artifact"></td>
-                <td><input type="checkbox" name="resell_market_option" value="Artifact"></td>
                 <td>Artifacts</td>
+                <td><input type="checkbox" name="resell_shops_option" value="Artifact"></td>
+                <td><input type="checkbox" name="resell_market_option" value="Artifact"></td>
+                <td><input type="checkbox" name="sale_option" value="Artifact"></td>
               </tr>
               <tr>
-                <td><input type="checkbox" name="resell_npc_option" value="Plushie"></td>
-                <td><input type="checkbox" name="resell_market_option" value="Plushie"></td>
                 <td>Plushies</td>
+                <td><input type="checkbox" name="resell_shops_option" value="Plushie"></td>
+                <td><input type="checkbox" name="resell_market_option" value="Plushie"></td>
+                <td><input type="checkbox" name="sale_option" value="Plushie"></td>
               </tr>
               <tr>
-                <td><input type="checkbox" name="resell_npc_option" value="Special"></td>
-                <td><input type="checkbox" name="resell_market_option" value="Special"></td>
                 <td>Special Items</td>
+                <td><input type="checkbox" name="resell_shops_option" value="Special"></td>
+                <td><input type="checkbox" name="resell_market_option" value="Special"></td>
+                <td><input type="checkbox" name="sale_option" value="Special"></td>
               </tr>
               <tr>
-                <td><input type="checkbox" name="resell_npc_option" value="Other"></td>
-                <td><input type="checkbox" name="resell_market_option" value="Other"></td>
                 <td>Miscellaneous</td>
+                <td><input type="checkbox" name="resell_shops_option" value="Other"></td>
+                <td><input type="checkbox" name="resell_market_option" value="Other"></td>
+                <td><input type="checkbox" name="sale_option" value="Other"></td>
               </tr>
             </tbody>
           </table>
-          <div class="text-align-center">
+          <div class="update-buttons">
             <button id="settingsbtn">Update settings</button>
           </div>
 

--- a/extension/popup/popup.html
+++ b/extension/popup/popup.html
@@ -25,7 +25,7 @@
             Maximum piggy bank expense: <input type="number" id="maxPiggyBankExpense" placeholder="450" value="450" min="1" class="input-normal">
         </div>
         <div class="text-align-center">
-          <button id="valuesbtn" onclick="setConfigValues()">Update values</button>
+          <button id="valuesbtn">Update values</button>
         </div>
     </div>
     <script src="popup.js"></script>

--- a/extension/popup/popup.js
+++ b/extension/popup/popup.js
@@ -35,30 +35,30 @@ async function setInitialValues() {
     } else {
         // default values
         let categorySettings = new Map()
-        categorySettings.set("Melee", {npc: true, market: false})
-        categorySettings.set("Primary", {npc: true, market: false})
-        categorySettings.set("Secondary", {npc: true, market: false})
-        categorySettings.set("Defensive", {npc: true, market: false})
-        categorySettings.set("Medical", {npc: true, market: true})
-        categorySettings.set("Temporary", {npc: true, market: false})
-        categorySettings.set("Energy", {npc: true, market: true})
-        categorySettings.set("Candy", {npc: true, market: true})
-        categorySettings.set("Drug", {npc: true, market: true})
-        categorySettings.set("Enhancer", {npc: true, market: false})
-        categorySettings.set("Alcohol", {npc: true, market: true})
-        categorySettings.set("Booster", {npc: true, market: false})
-        categorySettings.set("Electronic", {npc: true, market: false})
-        categorySettings.set("Jewelry", {npc: true, market: false})
-        categorySettings.set("Virus", {npc: true, market: false})
-        categorySettings.set("Flower", {npc: true, market: true})
-        categorySettings.set("Supply Pack", {npc: true, market: false})
-        categorySettings.set("Collectible", {npc: true, market: false})
-        categorySettings.set("Clothing", {npc: true, market: false})
-        categorySettings.set("Car", {npc: true, market: false})
-        categorySettings.set("Artifact", {npc: true, market: false})
-        categorySettings.set("Plushie", {npc: true, market: true})
-        categorySettings.set("Special", {npc: true, market: false})
-        categorySettings.set("Other", {npc: true, market: false})
+        categorySettings.set("Melee", {shop: true, market: false, sale: false})
+        categorySettings.set("Primary", {shop: true, market: false, sale: false})
+        categorySettings.set("Secondary", {shop: true, market: false, sale: false})
+        categorySettings.set("Defensive", {shop: true, market: false, sale: false})
+        categorySettings.set("Medical", {shop: true, market: true, sale: false})
+        categorySettings.set("Temporary", {shop: true, market: false, sale: false})
+        categorySettings.set("Energy Drink", {shop: true, market: true, sale: false})
+        categorySettings.set("Candy", {shop: true, market: true, sale: false})
+        categorySettings.set("Drug", {shop: true, market: true, sale: false})
+        categorySettings.set("Enhancer", {shop: true, market: false, sale: false})
+        categorySettings.set("Alcohol", {shop: true, market: true, sale: false})
+        categorySettings.set("Booster", {shop: true, market: false, sale: false})
+        categorySettings.set("Electronic", {shop: true, market: false, sale: false})
+        categorySettings.set("Jewelry", {shop: true, market: false, sale: false})
+        categorySettings.set("Virus", {shop: true, market: false, sale: false})
+        categorySettings.set("Flower", {shop: true, market: true, sale: false})
+        categorySettings.set("Supply Pack", {shop: true, market: false, sale: false})
+        categorySettings.set("Collectible", {shop: true, market: false, sale: false})
+        categorySettings.set("Clothing", {shop: true, market: false, sale: false})
+        categorySettings.set("Car", {shop: true, market: false, sale: false})
+        categorySettings.set("Artifact", {shop: true, market: false, sale: false})
+        categorySettings.set("Plushie", {shop: true, market: true, sale: false})
+        categorySettings.set("Special", {shop: true, market: false, sale: false})
+        categorySettings.set("Other", {shop: true, market: false, sale: false})
         RestoreCategorySettings(categorySettings)
     }
 
@@ -117,16 +117,22 @@ function SetConfigValues() {
 }
 
 function RestoreCategorySettings(categorySettings) {
-    let checkboxes = document.getElementsByName("resell_npc_option")
+    let checkboxes = document.getElementsByName("resell_shops_option")
     for(let i = 0; i < checkboxes.length; i++) {
-        let categorySetting = categorySettings.get(checkboxes[i].value)
-        if (categorySetting.npc) checkboxes[i].checked = true
+        let setting = categorySettings.get(checkboxes[i].value)
+        if (setting.shop) checkboxes[i].checked = true
     }
 
     checkboxes = document.getElementsByName("resell_market_option")
     for(let i = 0; i < checkboxes.length; i++) {
-        let categorySetting = categorySettings.get(checkboxes[i].value)
-        if (categorySetting.market) checkboxes[i].checked = true
+        let setting = categorySettings.get(checkboxes[i].value)
+        if (setting.market) checkboxes[i].checked = true
+    }
+
+    checkboxes = document.getElementsByName("sale_option")
+    for(let i = 0; i < checkboxes.length; i++) {
+        let setting = categorySettings.get(checkboxes[i].value)
+        if (setting.sale) checkboxes[i].checked = true
     }
 }
 
@@ -134,17 +140,24 @@ function UpdateCategorySettings() {
     // build map from category into {npc,market} obj representing intention
     let categorySettings = new Map()
 
-    let checkboxes = document.getElementsByName("resell_npc_option")
+    let checkboxes = document.getElementsByName("resell_shops_option")
     for(let i = 0; i < checkboxes.length; i++) {
-        let categorySetting = {npc: checkboxes[i].checked}
-        categorySettings.set(checkboxes[i].value, categorySetting)
+        let setting = {shop: checkboxes[i].checked}
+        categorySettings.set(checkboxes[i].value, setting)
     }
 
     checkboxes = document.getElementsByName("resell_market_option")
     for(let i = 0; i < checkboxes.length; i++) {
-        let categorySetting = categorySettings.get(checkboxes[i].value)
-        categorySetting.market = checkboxes[i].checked
-        categorySettings.set(checkboxes[i].value, categorySetting)
+        let setting = categorySettings.get(checkboxes[i].value)
+        setting.market = checkboxes[i].checked
+        categorySettings.set(checkboxes[i].value, setting)
+    }
+
+    checkboxes = document.getElementsByName("sale_option")
+    for(let i = 0; i < checkboxes.length; i++) {
+        let setting = categorySettings.get(checkboxes[i].value)
+        setting.sale = checkboxes[i].checked
+        categorySettings.set(checkboxes[i].value, setting)
     }
 
     categorySettingsObj = Object.fromEntries(categorySettings)

--- a/extension/popup/popup.js
+++ b/extension/popup/popup.js
@@ -1,7 +1,23 @@
 setInitialValues()
 
-document.querySelector("#apikeybtn").addEventListener("click", setApiKey)
-document.querySelector("#valuesbtn").addEventListener("click", setConfigValues)
+document.querySelector("#apikeybtn").addEventListener("click", SetApiKey)
+document.querySelector("#valuesbtn").addEventListener("click", SetConfigValues)
+document.querySelector("#settingsbtn").addEventListener("click", UpdateCategorySettings)
+
+var coll = document.getElementsByClassName("collapsible");
+var i;
+
+for (i = 0; i < coll.length; i++) {
+  coll[i].addEventListener("click", function() {
+    this.classList.toggle("active")
+    var content = this.nextElementSibling
+    if (content.style.display === "block") {
+      content.style.display = "none"
+    } else {
+      content.style.display = "block"
+    }
+  })
+} 
 
 async function setInitialValues() {
     let apiKey = await get("apiKey")
@@ -9,6 +25,42 @@ async function setInitialValues() {
     let minPercentage = await get("minPercentage")
     let minPiggyBankValue = await get("minPiggyBankValue")
     let maxPiggyBankExpense = await get("maxPiggyBankExpense")
+
+    let categorySettingsObj = await get("categorySettingsObj")
+    if (typeof categorySettingsObj !== 'undefined') {
+        let categorySettings = new Map(Object.entries(categorySettingsObj))
+        if (categorySettings.size !== 0) {
+            RestoreCategorySettings(categorySettings)
+        }
+    } else {
+        // default values
+        let categorySettings = new Map()
+        categorySettings.set("Melee", {npc: true, market: false})
+        categorySettings.set("Primary", {npc: true, market: false})
+        categorySettings.set("Secondary", {npc: true, market: false})
+        categorySettings.set("Defensive", {npc: true, market: false})
+        categorySettings.set("Medical", {npc: true, market: true})
+        categorySettings.set("Temporary", {npc: true, market: false})
+        categorySettings.set("Energy", {npc: true, market: true})
+        categorySettings.set("Candy", {npc: true, market: true})
+        categorySettings.set("Drug", {npc: true, market: true})
+        categorySettings.set("Enhancer", {npc: true, market: false})
+        categorySettings.set("Alcohol", {npc: true, market: true})
+        categorySettings.set("Booster", {npc: true, market: false})
+        categorySettings.set("Electronic", {npc: true, market: false})
+        categorySettings.set("Jewelry", {npc: true, market: false})
+        categorySettings.set("Virus", {npc: true, market: false})
+        categorySettings.set("Flower", {npc: true, market: true})
+        categorySettings.set("Supply Pack", {npc: true, market: false})
+        categorySettings.set("Collectible", {npc: true, market: false})
+        categorySettings.set("Clothing", {npc: true, market: false})
+        categorySettings.set("Car", {npc: true, market: false})
+        categorySettings.set("Artifact", {npc: true, market: false})
+        categorySettings.set("Plushie", {npc: true, market: true})
+        categorySettings.set("Special", {npc: true, market: false})
+        categorySettings.set("Other", {npc: true, market: false})
+        RestoreCategorySettings(categorySettings)
+    }
 
     if (!apiKey || apiKey === "") {
         console.log("[TM+] API key not found!")
@@ -25,7 +77,7 @@ async function setInitialValues() {
     // console.log(`[TM+] opened popup with apiKey: ${apiKey}, min profit: ${minProfit}, min percentage: ${minPercentage}, min piggy bank ${minPiggyBankValue}, max piggy bank expense: ${maxPiggyBankExpense}`)
 }
 
-function setApiKey() {
+function SetApiKey() {
     let apiKey = document.querySelector("#apikey").value
     if (apiKey == "") {
         // invalid
@@ -35,7 +87,7 @@ function setApiKey() {
     console.log(`[TM+] API key stored!`)
 }
 
-function setConfigValues() {
+function SetConfigValues() {
     let minProfit = document.querySelector("#minProfit").value
     if (minProfit == "" || minProfit < 1) {
         // invalid
@@ -62,6 +114,41 @@ function setConfigValues() {
     set({maxPiggyBankExpense})
     
     // console.log(`[TM+] updated values: min profit: ${minProfit}, min percentage: ${minPercentage}, min piggy bank ${minPiggyBankValue}, max piggy bank expense: ${maxPiggyBankExpense}`)
+}
+
+function RestoreCategorySettings(categorySettings) {
+    let checkboxes = document.getElementsByName("resell_npc_option")
+    for(let i = 0; i < checkboxes.length; i++) {
+        let categorySetting = categorySettings.get(checkboxes[i].value)
+        if (categorySetting.npc) checkboxes[i].checked = true
+    }
+
+    checkboxes = document.getElementsByName("resell_market_option")
+    for(let i = 0; i < checkboxes.length; i++) {
+        let categorySetting = categorySettings.get(checkboxes[i].value)
+        if (categorySetting.market) checkboxes[i].checked = true
+    }
+}
+
+function UpdateCategorySettings() {
+    // build map from category into {npc,market} obj representing intention
+    let categorySettings = new Map()
+
+    let checkboxes = document.getElementsByName("resell_npc_option")
+    for(let i = 0; i < checkboxes.length; i++) {
+        let categorySetting = {npc: checkboxes[i].checked}
+        categorySettings.set(checkboxes[i].value, categorySetting)
+    }
+
+    checkboxes = document.getElementsByName("resell_market_option")
+    for(let i = 0; i < checkboxes.length; i++) {
+        let categorySetting = categorySettings.get(checkboxes[i].value)
+        categorySetting.market = checkboxes[i].checked
+        categorySettings.set(checkboxes[i].value, categorySetting)
+    }
+
+    categorySettingsObj = Object.fromEntries(categorySettings)
+    set({categorySettingsObj})
 }
 
 function get(key) {

--- a/extension/popup/popup.js
+++ b/extension/popup/popup.js
@@ -1,5 +1,8 @@
 setInitialValues()
 
+document.querySelector("#apikeybtn").addEventListener("click", setApiKey)
+document.querySelector("#valuesbtn").addEventListener("click", setConfigValues)
+
 async function setInitialValues() {
     let apiKey = await get("apiKey")
     let minProfit = await get("minProfit")
@@ -8,7 +11,7 @@ async function setInitialValues() {
     let maxPiggyBankExpense = await get("maxPiggyBankExpense")
 
     if (!apiKey || apiKey === "") {
-        console.log("no api key")
+        console.log("[TM+] API key not found!")
         // TODO handle case
     } else {
         document.querySelector("#apikey").value = apiKey
@@ -18,22 +21,21 @@ async function setInitialValues() {
     if (minPercentage) document.querySelector("#minPercentage").value = minPercentage
     if (minPiggyBankValue) document.querySelector("#minPiggyBankValue").value = minPiggyBankValue
     if (maxPiggyBankExpense) document.querySelector("#maxPiggyBankExpense").value = maxPiggyBankExpense
+
+    // console.log(`[TM+] opened popup with apiKey: ${apiKey}, min profit: ${minProfit}, min percentage: ${minPercentage}, min piggy bank ${minPiggyBankValue}, max piggy bank expense: ${maxPiggyBankExpense}`)
 }
 
-document.querySelector("#apikeybtn").addEventListener("click", setApiKey)
-document.querySelector("#valuesbtn").addEventListener("click", setConfigValues)
-
-async function setApiKey() {
+function setApiKey() {
     let apiKey = document.querySelector("#apikey").value
     if (apiKey == "") {
         // invalid
     }
-    // console.log(`[TM+] api key: ${apiKey}`)
-    await set({apiKey})
+    set({apiKey})
+    
+    console.log(`[TM+] API key stored!`)
 }
 
-async function setConfigValues() {
-    console.log("setConfigValues")
+function setConfigValues() {
     let minProfit = document.querySelector("#minProfit").value
     if (minProfit == "" || minProfit < 1) {
         // invalid
@@ -54,11 +56,12 @@ async function setConfigValues() {
         // invalid
     }
 
-    console.log(`[TM+] min profit: ${minProfit}, min percentage: ${minPercentage}, min piggy bank ${minPiggyBankValue}, max piggy bank expense: ${maxPiggyBankExpense}`)
-    await set(minProfit)
-    await set(minPercentage)
-    await set(minPiggyBankValue)
-    await set(maxPiggyBankExpense)
+    set({minProfit})
+    set({minPercentage})
+    set({minPiggyBankValue})
+    set({maxPiggyBankExpense})
+    
+    // console.log(`[TM+] updated values: min profit: ${minProfit}, min percentage: ${minPercentage}, min piggy bank ${minPiggyBankValue}, max piggy bank expense: ${maxPiggyBankExpense}`)
 }
 
 function get(key) {

--- a/extension/scripts/background/background.js
+++ b/extension/scripts/background/background.js
@@ -58,7 +58,8 @@ async function fetchItemsFromAPI () {
             key, 
             {
                 price: data.items[key].sell_price,
-                marketPrice: data.items[key].market_value
+                marketPrice: data.items[key].market_value,
+                category: data.items[key].type
             }
         )
         count++

--- a/extension/scripts/content/bazaar/highlight.js
+++ b/extension/scripts/content/bazaar/highlight.js
@@ -4,6 +4,11 @@ showHighlight()
 listenForChanges()
 saveBazaar()
 
+function saveBazaar() {
+    let lastBazaar = window.location.href
+    set({lastBazaar})
+}
+
 async function showHighlight() {
     console.log("[TM+] bazaar highlight script started")
 
@@ -51,6 +56,9 @@ async function showHighlight() {
             continue
         }
 
+        // TODO use when the handleProfitResell is added
+        // if (!categoriesWithResellingProfit.includes(apiItem.category)) continue
+
         let profitElement = handleProfit(apiItem.price, currentPrice, desiredMinProfit)
         if (profitElement) {
             item.classList.add("tmm-highlight")
@@ -93,9 +101,10 @@ function handleProfit(sellingPrice, currentPrice, desiredMinProfit) {
 // Decide if discount is within desired margin and build the node if needed.
 // Filters out categories not present in the `category` array.
 function handleDiscount(marketPrice, currentPrice, category, desiredMinPercentage) {
+    if (!categoriesWithDiscounts.includes(category)) return
+
     if (!marketPrice) return // a few items don't have one, I.G. "Cleaver"
 
-    // if (!categoriesWithDiscounts.includes(category)) return
     let discountPercentage = 100 - Math.round(currentPrice * 100 / marketPrice)
     if (discountPercentage < desiredMinPercentage) return
 
@@ -208,9 +217,4 @@ async function handleNewRow(pricesTable, newRow) {
             wrapper.appendChild(piggyBankElement)
         }
     }
-}
-
-function saveBazaar() {
-    let lastBazaar = window.location.href
-    set({lastBazaar})
 }

--- a/extension/scripts/content/intercept/xhr-requests.js
+++ b/extension/scripts/content/intercept/xhr-requests.js
@@ -5,7 +5,8 @@
 
 	window.XMLHttpRequest.prototype.open = function (method, url) {
 		this.addEventListener("readystatechange", function () {
-			if (method === 'POST' && this.readyState > 3 && this.status === 200) {
+			if (method === 'POST' && this.readyState > 3 && this.status === 200 && this.requestBody) {
+				
 				// listing page, update item:
 				// this.requestBody = step=changePrice&ID=146866501&price=551
 				// ID is not of the item but the listing itself

--- a/extension/scripts/content/market/highlight.js
+++ b/extension/scripts/content/market/highlight.js
@@ -32,8 +32,6 @@ async function showHighlight() {
 
     await requireElement(".item-market-wrap div[aria-expanded='true'] li[data-item]", 20) // 5s
 
-    let category = document.querySelector("[data-cat][aria-selected='true']").getAttribute("data-type")
-
     for (let item of document.querySelectorAll(".item-market-wrap div[aria-expanded='true'] li[data-item]")) {
         const itemID = item.children[0].getAttribute("itemid")
         
@@ -55,7 +53,7 @@ async function showHighlight() {
         let wrapperElement = document.createElement("div")
         wrapperElement.classList.add("tmm-wrapper")
 
-        if (categorySettings.get(apiItem.category).npc) {
+        if (categorySettings.get(apiItem.category).shop) {
             let profitElement = handleProfit(apiItem.price, currentPrice, desiredMinProfit)
             if (profitElement) {
                 wrapperElement.appendChild(profitElement)
@@ -73,10 +71,12 @@ async function showHighlight() {
             }
         }
 
-        let discountElement = handleDiscount(apiItem.marketPrice, currentPrice, category, desiredMinPercentage)
-        if (discountElement) {
-            let wrapper = item.querySelector(":scope .qty-wrap")
-            wrapper.appendChild(discountElement)
+        if (categorySettings.get(apiItem.category).sale) {
+            let discountElement = handleDiscount(apiItem.marketPrice, currentPrice, desiredMinPercentage)
+            if (discountElement) {
+                let wrapper = item.querySelector(":scope .qty-wrap")
+                wrapper.appendChild(discountElement)
+            }
         }
 
         let piggyBankElement = handlePiggyBank(apiItem.price, currentPrice, desiredMinPiggyBank, desiredMaxPiggyBankExpense)
@@ -127,12 +127,9 @@ function handleProfitResell(marketPrice, currentPrice) {
 }
 
 // Decide if discount is within desired margin and build the node if needed.
-// Filters out categories not present in the `category` array.
-function handleDiscount(marketPrice, currentPrice, category, desiredMinPercentage) {
+function handleDiscount(marketPrice, currentPrice, desiredMinPercentage) {
     // console.log(`[TM+] handleDiscount: ${marketPrice}, ${currentPrice}, ${category}, ${desiredMinPercentage}`)
     if (!marketPrice) return // a few items don't have one, I.G. "Cleaver"
-
-    if (!categoriesWithDiscounts.includes(category)) return
     
     let discountPercentage = 100 - Math.round(currentPrice * 100 / marketPrice)
     if (discountPercentage < desiredMinPercentage) return

--- a/extension/scripts/content/market/highlight.js
+++ b/extension/scripts/content/market/highlight.js
@@ -1,11 +1,5 @@
 "use strict"
 
-// categories (from the market left side panel) where discount percentages will be shown
-let categoriesWithDiscounts = ["medical-items", "temporary-items", "energy-drinks", "candy", "drugs", "enhancers", "alcohol", "flowers", "clothing", "plushies", "special-items"]
-
-// categories (from the market left side panel) where reselling profit will be shown
-let categoriesWithResellingProfit = ["flowers", "plushies"]
-
 window.addEventListener("refresh-market-highlight", showHighlight)
 
 showHighlight()
@@ -37,7 +31,7 @@ async function showHighlight() {
 
     await requireElement(".item-market-wrap div[aria-expanded='true'] li[data-item]", 20) // 5s
 
-    let category = document.querySelector("[data-cat][aria-selected='true']").getAttribute("data-cat")
+    let category = document.querySelector("[data-cat][aria-selected='true']").getAttribute("data-type")
 
     for (let item of document.querySelectorAll(".item-market-wrap div[aria-expanded='true'] li[data-item]")) {
         const itemID = item.children[0].getAttribute("itemid")

--- a/extension/scripts/content/utils/utils.js
+++ b/extension/scripts/content/utils/utils.js
@@ -1,32 +1,19 @@
 "use strict"
 
-// Minimum amount of profit necessary to show the highlight and value you would
-// get from buying and then reselling that item
+// Minimum profit from reselling the item on the NPC stores to show highlights
 const defaultMinProfit = 450
-// TODO
+// Minimum profit from reselling the item on the market to show highlights 
 const defaultMinProfitResell = 200
-// Minimum percentage necessary to show the discount element over an item
+// Minimum percentage to show the sale icon over an item
 const defaultMinPercentage = 25
 // Minimum value of an item necessary to consider showing the piggy bank icon
 const defaultMinPiggyBankValue = 20000
-// Maximum amount you're willing to overpay for an item when doing so with the
-// goal of storing money away
+// Maximum amount you're willing to overpay for an item when storing away money
 const defaultMaxPiggyBankExpense = 450
-
-// Market category names on the market side panel don't exactly match the ones from the
-// api. This map helps with that, mapping the UI name into what to expect from the API
-// const categoriesMap = new Map(
-//     ["medical-items", "Medical"],
-//     ["temporary-items", "Temporary"],
-//     ["energy-drinks", "Energy Drink"],
-//     ["candy", "Drug"],
-//     ["enhancers", "Enhancer"],
-//     ["alcohol", "Alcohol"],
-//     ["flowers", "Flower"],
-//     ["clothing", "Clothing"],
-//     ["plushies", "Plushie"],
-//     ["special-items", "Special"],
-// )
+// Categories where discount percentages will be shown
+const categoriesWithDiscounts = ["Flower", "Plushie", "Drug", "Alcohol", "Energy Drink", "Temporary", "Medical", "Enhancer", "Clothing", "Special", "Candy"]
+// Categories where reselling profit will be shown
+const categoriesWithResellingProfit = ["Flower", "Plushie", "Drug", "Alcohol", "Energy Drink", "Candy"]
 
 injectXHR()
 
@@ -119,7 +106,8 @@ async function fetchItemsFromAPI () {
             key, 
             {
                 price: data.items[key].sell_price,
-                marketPrice: data.items[key].market_value
+                marketPrice: data.items[key].market_value,
+                category: data.items[key].type
             }
         )
         count++
@@ -134,7 +122,7 @@ async function getPricesTable() {
     if (typeof pricesTableObj !== 'undefined') {
         let pricesTable = new Map(Object.entries(pricesTableObj))
         if (pricesTable.size !== 0) {
-            console.log("[TM+] prices table fetched from storage. Size: " + pricesTable.size)
+            // console.log("[TM+] prices table fetched from storage. Size: " + pricesTable.size)
             return pricesTable
         }
     }
@@ -149,7 +137,7 @@ async function getPricesTable() {
     }
 
     pricesTableObj = Object.fromEntries(pricesTable)
-    set(pricesTableObj)
+    set({pricesTableObj})
     return pricesTable
 }
 

--- a/extension/scripts/content/utils/utils.js
+++ b/extension/scripts/content/utils/utils.js
@@ -10,8 +10,6 @@ const defaultMinPercentage = 25
 const defaultMinPiggyBankValue = 20000
 // Maximum amount you're willing to overpay for an item when storing away money
 const defaultMaxPiggyBankExpense = 450
-// Categories where discount percentages are shown
-const categoriesWithDiscounts = ["Melee", "Primary", "Flower", "Plushie", "Drug", "Alcohol", "Energy Drink", "Temporary", "Medical", "Enhancer", "Clothing", "special", "Candy"]
 
 injectXHR()
 
@@ -126,30 +124,30 @@ async function getCategorySettings() {
 
     // default values
     let categorySettings = new Map()
-    categorySettings.set("Melee", {npc: true, market: false})
-    categorySettings.set("Primary", {npc: true, market: false})
-    categorySettings.set("Secondary", {npc: true, market: false})
-    categorySettings.set("Defensive", {npc: true, market: false})
-    categorySettings.set("Medical", {npc: true, market: true})
-    categorySettings.set("Temporary", {npc: true, market: false})
-    categorySettings.set("Energy", {npc: true, market: true})
-    categorySettings.set("Candy", {npc: true, market: true})
-    categorySettings.set("Drug", {npc: true, market: true})
-    categorySettings.set("Enhancer", {npc: true, market: false})
-    categorySettings.set("Alcohol", {npc: true, market: true})
-    categorySettings.set("Booster", {npc: true, market: false})
-    categorySettings.set("Electronic", {npc: true, market: false})
-    categorySettings.set("Jewelry", {npc: true, market: false})
-    categorySettings.set("Virus", {npc: true, market: false})
-    categorySettings.set("Flower", {npc: true, market: true})
-    categorySettings.set("Supply Pack", {npc: true, market: false})
-    categorySettings.set("Collectible", {npc: true, market: false})
-    categorySettings.set("Clothing", {npc: true, market: false})
-    categorySettings.set("Car", {npc: true, market: false})
-    categorySettings.set("Artifact", {npc: true, market: false})
-    categorySettings.set("Plushie", {npc: true, market: true})
-    categorySettings.set("Special", {npc: true, market: false})
-    categorySettings.set("Other", {npc: true, market: false})
+    categorySettings.set("Melee", {shop: true, market: false, sale: false})
+    categorySettings.set("Primary", {shop: true, market: false, sale: false})
+    categorySettings.set("Secondary", {shop: true, market: false, sale: false})
+    categorySettings.set("Defensive", {shop: true, market: false, sale: false})
+    categorySettings.set("Medical", {shop: true, market: true, sale: false})
+    categorySettings.set("Temporary", {shop: true, market: false, sale: false})
+    categorySettings.set("Energy Drink", {shop: true, market: true, sale: false})
+    categorySettings.set("Candy", {shop: true, market: true, sale: false})
+    categorySettings.set("Drug", {shop: true, market: true, sale: false})
+    categorySettings.set("Enhancer", {shop: true, market: false, sale: false})
+    categorySettings.set("Alcohol", {shop: true, market: true, sale: false})
+    categorySettings.set("Booster", {shop: true, market: false, sale: false})
+    categorySettings.set("Electronic", {shop: true, market: false, sale: false})
+    categorySettings.set("Jewelry", {shop: true, market: false, sale: false})
+    categorySettings.set("Virus", {shop: true, market: false, sale: false})
+    categorySettings.set("Flower", {shop: true, market: true, sale: false})
+    categorySettings.set("Supply Pack", {shop: true, market: false, sale: false})
+    categorySettings.set("Collectible", {shop: true, market: false, sale: false})
+    categorySettings.set("Clothing", {shop: true, market: false, sale: false})
+    categorySettings.set("Car", {shop: true, market: false, sale: false})
+    categorySettings.set("Artifact", {shop: true, market: false, sale: false})
+    categorySettings.set("Plushie", {shop: true, market: true, sale: false})
+    categorySettings.set("Special", {shop: true, market: false, sale: false})
+    categorySettings.set("Other", {shop: true, market: false, sale: false})
     return categorySettings
 }
 

--- a/extension/scripts/content/utils/utils.js
+++ b/extension/scripts/content/utils/utils.js
@@ -10,10 +10,8 @@ const defaultMinPercentage = 25
 const defaultMinPiggyBankValue = 20000
 // Maximum amount you're willing to overpay for an item when storing away money
 const defaultMaxPiggyBankExpense = 450
-// Categories where discount percentages will be shown
-const categoriesWithDiscounts = ["Flower", "Plushie", "Drug", "Alcohol", "Energy Drink", "Temporary", "Medical", "Enhancer", "Clothing", "Special", "Candy"]
-// Categories where reselling profit will be shown
-const categoriesWithResellingProfit = ["Flower", "Plushie", "Drug", "Alcohol", "Energy Drink", "Candy"]
+// Categories where discount percentages are shown
+const categoriesWithDiscounts = ["Melee", "Primary", "Flower", "Plushie", "Drug", "Alcohol", "Energy Drink", "Temporary", "Medical", "Enhancer", "Clothing", "special", "Candy"]
 
 injectXHR()
 
@@ -115,6 +113,44 @@ async function fetchItemsFromAPI () {
 
     console.log(`[TM+] API request successful, got ${count} items`)
     return pricesTable
+}
+
+async function getCategorySettings() {
+    let categorySettingsObj = await get("categorySettingsObj")
+    if (typeof categorySettingsObj !== 'undefined') {
+        let categorySettings = new Map(Object.entries(categorySettingsObj))
+        if (categorySettings.size !== 0) {
+            return categorySettings
+        }
+    }
+
+    // default values
+    let categorySettings = new Map()
+    categorySettings.set("Melee", {npc: true, market: false})
+    categorySettings.set("Primary", {npc: true, market: false})
+    categorySettings.set("Secondary", {npc: true, market: false})
+    categorySettings.set("Defensive", {npc: true, market: false})
+    categorySettings.set("Medical", {npc: true, market: true})
+    categorySettings.set("Temporary", {npc: true, market: false})
+    categorySettings.set("Energy", {npc: true, market: true})
+    categorySettings.set("Candy", {npc: true, market: true})
+    categorySettings.set("Drug", {npc: true, market: true})
+    categorySettings.set("Enhancer", {npc: true, market: false})
+    categorySettings.set("Alcohol", {npc: true, market: true})
+    categorySettings.set("Booster", {npc: true, market: false})
+    categorySettings.set("Electronic", {npc: true, market: false})
+    categorySettings.set("Jewelry", {npc: true, market: false})
+    categorySettings.set("Virus", {npc: true, market: false})
+    categorySettings.set("Flower", {npc: true, market: true})
+    categorySettings.set("Supply Pack", {npc: true, market: false})
+    categorySettings.set("Collectible", {npc: true, market: false})
+    categorySettings.set("Clothing", {npc: true, market: false})
+    categorySettings.set("Car", {npc: true, market: false})
+    categorySettings.set("Artifact", {npc: true, market: false})
+    categorySettings.set("Plushie", {npc: true, market: true})
+    categorySettings.set("Special", {npc: true, market: false})
+    categorySettings.set("Other", {npc: true, market: false})
+    return categorySettings
 }
 
 async function getPricesTable() {

--- a/manifests/chrome-manifest.json
+++ b/manifests/chrome-manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 3,
   "name": "TornMarket+",
-  "version": "0.1.2",
-  "description": "Provides additional information and features on the market related pages of the game Torn.",
+  "version": "0.1.3",
+  "description": "Provides additional information and features on the market pages of the game Torn.",
   "author": "Ricardo Osorio - BOTLoki [2742316]",
   "permissions": [
     "storage",

--- a/manifests/firefox-manifest.json
+++ b/manifests/firefox-manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 2,
   "name": "TornMarket+",
-  "version": "0.1.2",
-  "description": "Provides additional information and features on the market related pages of the game Torn.",
+  "version": "0.1.3",
+  "description": "Provides additional information and features on the market pages of the game Torn.",
   "author": "Ricardo Osorio - BOTLoki [2742316]",
   "permissions": [
     "storage",


### PR DESCRIPTION
- Removed inline script from popup due to being against chrome's policy
- Fixed outdated comments
- Fixed popup values not being stored correctly all the time
- Now storing the API items categories together with the rest of the data
- Updated how items categories are fetched from the DOM (different element attribute that matches with the API data)
- Bazaar script now filters out items not on the predefined categories.
- Updated popup with new table that allows to select in which categories the profit elements should show up
- Bazaar and Market now filter out items based on desired settings (popup selection)
- Remove previously hardcoded categories
- Other small fixes like early returns and extra undefined checks
- Bumped version to 0.1.3